### PR TITLE
[Feat/#5] 전체적인 Entity 및 연관관계 구현하기

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -10,6 +10,7 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/backend" />
+            <option value="$PROJECT_DIR$/frontend" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -10,7 +10,6 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/backend" />
-            <option value="$PROJECT_DIR$/frontend" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/backend/src/main/java/org/example/backend/BackendApplication.java
+++ b/backend/src/main/java/org/example/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package org.example.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/org/example/backend/domain/news/entity/News.java
+++ b/backend/src/main/java/org/example/backend/domain/news/entity/News.java
@@ -1,0 +1,43 @@
+package org.example.backend.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "news")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class News extends BaseEntity {     /** 뉴스 요약 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 관련 종목 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    /** 뉴스 제목 **/
+    @Column(name = "title", length = 200)
+    private String title;
+
+    /** 뉴스 본문 내용 (TEXT) **/
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    /** 뉴스 요약 (JSONB) **/
+    @Column(name = "summary", columnDefinition = "jsonb")
+    private String summary;
+
+    /** 뉴스 공개 일시 **/
+    @Column(name = "published_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    private OffsetDateTime publishedAt;
+
+}

--- a/backend/src/main/java/org/example/backend/domain/notification/entity/Notification.java
+++ b/backend/src/main/java/org/example/backend/domain/notification/entity/Notification.java
@@ -1,0 +1,48 @@
+package org.example.backend.domain.notification.entity;
+
+import jakarta.persistence.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.global.entity.BaseEntity;
+import org.example.backend.type.NotificationType;
+
+@Entity
+@Table(name = "notification")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification extends BaseEntity {      /** 알림 **/
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 알림 수신 대상 사용자 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** 관련 종목 - 선택적 FK **/
+    @Column(name = "stock_id")
+    private Long stockId;
+
+    /** 알림 유형 (NOT NULL)
+     * PRICE_DROP("급락 알림"),
+     * NEWS_EVENT("뉴스 발생 알림"),
+     * THRESHOLD("수익률/목표가 임계치 초과 알림") **/
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 50)
+    private NotificationType type;
+
+    /** 알림 메시지 (NOT NULL) **/
+    @Column(name = "message", nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    /** 읽음 여부 (NOT NULL, DEFAULT FALSE) **/
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+}

--- a/backend/src/main/java/org/example/backend/domain/portfolio/entity/Portfolio.java
+++ b/backend/src/main/java/org/example/backend/domain/portfolio/entity/Portfolio.java
@@ -1,0 +1,40 @@
+package org.example.backend.domain.portfolio.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.transaction.entity.Transaction;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "portfolio")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Portfolio extends BaseEntity {     /** 포트폴리오 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 소유자 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** 포트올리오 이름 (NOT NULL) **/
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    /** 포트폴리오 설명 (TEXT) **/
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Transaction> transactions = new HashSet<>();
+
+}

--- a/backend/src/main/java/org/example/backend/domain/prediction/entity/Prediction.java
+++ b/backend/src/main/java/org/example/backend/domain/prediction/entity/Prediction.java
@@ -1,0 +1,45 @@
+package org.example.backend.domain.prediction.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.prediction_model.entity.PredictionModel;
+import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "prediction")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Prediction extends BaseEntity {   /** 예측 결과 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 예측 대상 종목 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    /** 사용된 모델 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "model_id", nullable = false)
+    private PredictionModel model;
+
+    /** 예측 수행 일시 (NOT NULL) **/
+    @Column(name = "predicted_at", nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    private OffsetDateTime predictedAt;
+
+    /** 예측 결과 데이터 (JSONB, NOT NULL) **/
+    @Column(name = "result", nullable = false, columnDefinition = "jsonb")
+    private String result;
+
+    /** 예측 메타데이터 (JSONB) **/
+    @Column(name = "metadata", columnDefinition = "jsonb")
+    private String metadata;
+
+}

--- a/backend/src/main/java/org/example/backend/domain/prediction_model/entity/PredictionModel.java
+++ b/backend/src/main/java/org/example/backend/domain/prediction_model/entity/PredictionModel.java
@@ -1,0 +1,45 @@
+package org.example.backend.domain.prediction_model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.prediction.entity.Prediction;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "prediction_model",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_prediction_model_name", columnNames = {"model_name"})
+        })
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PredictionModel extends BaseEntity {  /** 예측 모델 메타정보 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 모델 이름 (NOT NULL, UNIQUE) **/
+    @Column(name = "model_name", nullable = false, length = 100)
+    private String modelName;
+
+    /** 알고리즘 (예: LSTM, RandomForest) **/
+    @Column(name = "algorithm", length = 100)
+    private String algorithm;
+
+    /** 모델 정확도 (REAL) **/
+    @Column(name = "accuracy", columnDefinition = "REAL")
+    private BigDecimal accuracy;
+
+    /** 하이퍼파라미터 정보 (JSONB) **/
+    @Column(name = "hyper_parameters", columnDefinition = "jsonb")
+    private String hyperParameters;
+
+    @OneToMany(mappedBy = "model", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Prediction> predictions = new HashSet<>();
+}

--- a/backend/src/main/java/org/example/backend/domain/stock/entity/Stock.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/entity/Stock.java
@@ -1,0 +1,57 @@
+package org.example.backend.domain.stock.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.news.entity.News;
+import org.example.backend.domain.prediction.entity.Prediction;
+import org.example.backend.domain.transaction.entity.Transaction;
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "stock",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_stock_symbol", columnNames = {"symbol"})
+        })
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Stock extends BaseEntity {     /** 종목 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 주식 티커 (NOT NULL, UNIQUE) **/
+    @Column(name = "symbol", nullable = false, length = 20)
+    private String symbol;
+
+    /** 종목 이름 **/
+    @Column(name = "name", length = 100)
+    private String name;
+
+    /** 거래소/시장 (예: NASDAQ) **/
+    @Column(name = "market", length = 50)
+    private String market;
+
+    /** 업종 (예: Technology) **/
+    @Column(name = "sector", length = 50)
+    private String sector;
+
+    @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Transaction> transactions = new HashSet<>();
+
+    @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Prediction> predictions = new HashSet<>();
+
+    @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<News> news = new HashSet<>();
+
+    @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<WatchList> watchList = new HashSet<>();
+
+}

--- a/backend/src/main/java/org/example/backend/domain/transaction/entity/Transaction.java
+++ b/backend/src/main/java/org/example/backend/domain/transaction/entity/Transaction.java
@@ -1,0 +1,64 @@
+package org.example.backend.domain.transaction.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.portfolio.entity.Portfolio;
+import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.global.entity.BaseEntity;
+import org.example.backend.type.TradeType;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "transaction")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Transaction extends BaseEntity {       /** 매수/매도 거래 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 거래가 속한 포트폴리오 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "portfolio_id", nullable = false)
+    private Portfolio portfolio;
+
+    /** 거래 대상 종목 (NOT NULL) **/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    /** 거래 일시 (NOT NULL) **/
+    @Column(name = "transaction_date", nullable = false, columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    private OffsetDateTime transactionDate;
+
+    /** 거래 유형 (NOT NULL, BUY ot SELL) **/
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_type", nullable = false, length = 10)
+    private TradeType tradeType;
+
+    /** 거래 수량 (NOT NULL) **/
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    /** 거래 단가 (NOT NULL) **/
+    @Column(name = "price", nullable = false, precision = 15, scale = 2)
+    private BigDecimal price;
+
+    /** 거래 총액 = quantity × price (NOT NULL) */
+    @Column(name = "total_amount", nullable = false, precision = 20, scale = 2)
+    private BigDecimal totalAmount;
+
+    /** 저장/업데이트 직전에 총액을 자동 계산 */
+    @PrePersist
+    @PreUpdate
+    public void calculateTotalAmount() {
+        if (this.price != null && this.quantity != null) {
+            this.totalAmount = this.price.multiply(BigDecimal.valueOf(this.quantity));
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/org/example/backend/domain/user/entity/User.java
@@ -1,0 +1,68 @@
+package org.example.backend.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.notification.entity.Notification;
+import org.example.backend.domain.portfolio.entity.Portfolio;
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.global.entity.BaseEntity;
+import org.example.backend.type.LoginType;
+import org.example.backend.type.RoleType;
+
+import java.util.*;
+
+@Entity
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_user_login_type_email",
+                        columnNames = {"login_type", "email"}),
+                @UniqueConstraint(name = "uq_user_login_type_provider",
+                        columnNames = {"login_type", "provider_id"})
+        })
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntity {      /** 사용자 **/
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 로컬 로그인인 경우에만 사용되는 이메일/아이디
+    @Column(name = "email", length = 100)
+    private String email;
+
+    // LOCAL 로그인 시에만 저장할 비밀번호(암호화된 해시). 소셜 로그인 시 null 가능
+    @Column(name = "password", length = 100)
+    private String password;
+
+    // KAKAO, GOOGLE 로그인 시 프로바이더에서 내려준 고유 식별자(ID)
+    @Column(name = "provider_id", length = 100)
+    private String providerId;
+
+    // 닉네임
+    @Column(name = "nickname", length = 50)
+    private String nickname;
+
+    // 로그인 유형(NOT NULL, LOCAL or KAKAO or GOOGLE)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type", nullable = false, length = 20)
+    private LoginType loginType;
+
+    // 역할 유형 (NOT NULL, ROLE_USER or ROLE_ADMIN)
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_type", nullable = false, length = 20)
+    private RoleType role = RoleType.ROLE_USER;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Notification> notifications = new HashSet<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Portfolio> portfolios = new HashSet<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<WatchList> watchList = new HashSet<>();
+
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchList.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchList.java
@@ -1,0 +1,32 @@
+package org.example.backend.domain.watch_list.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.global.entity.BaseEntity;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "watchlist")
+@IdClass(WatchListId.class)
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WatchList extends BaseEntity {    /** 관심 종목 **/
+
+    /** 복합키: user_id (NOT NULL) */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** 복합키: stock_id (NOT NULL) */
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchListId.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchListId.java
@@ -1,0 +1,30 @@
+package org.example.backend.domain.watch_list.entity;
+
+
+import lombok.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * WatchList의 복합키 (user_id, stock_id)를 표현
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchListId implements Serializable {
+
+    private Long user;
+    private Long stock;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WatchListId that = (WatchListId) o;
+        return Objects.equals(user, that.user) && Objects.equals(stock, that.stock);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, stock);
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/SwaggerConfig.java
@@ -18,8 +18,8 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-            .title("통합 인증 프로젝트")
-            .description("Spring doc를 사용한 auth system swagger UI")
+            .title("주식 가격 예측 대시보드 프로젝트")
+            .description("Spring doc를 사용한 PredicTick swagger UI")
             .version("1.0.0");
     }
 

--- a/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
+++ b/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
@@ -20,19 +20,16 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(name = "created_at", updatable = false)
+    @Column(updatable = false)
     private LocalDateTime createdAt;    // 엔티티 최초 저장 시 자동 입력
 
     @LastModifiedDate
-    @Column(name = "updated_at")
     private LocalDateTime updatedAt;    // 엔티티 수정 시 자동 갱신
 
     @CreatedBy
-    @Column(name = "created_by")
     private String createdBy;           // 데이터를 생성한 주체, Spring Security와 연동하여 자동 주입
 
     @LastModifiedBy
-    @Column(name = "last_modified_by")
     private String lastModifiedBy;      // 마지막으로 수정한 주체, 자동 주입
 
     // soft delete 플래그

--- a/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
+++ b/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
@@ -1,0 +1,41 @@
+package org.example.backend.global.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;    // 엔티티 최초 저장 시 자동 입력
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;    // 엔티티 수정 시 자동 갱신
+
+    @CreatedBy
+    @Column(name = "created_by")
+    private String createdBy;           // 데이터를 생성한 주체, Spring Security와 연동하여 자동 주입
+
+    @LastModifiedBy
+    @Column(name = "last_modified_by")
+    private String lastModifiedBy;      // 마지막으로 수정한 주체, 자동 주입
+
+    // soft delete 플래그
+    private boolean deleted = false;    // 실제 삭제 대신 플래그로 관리한다.
+
+}

--- a/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
+++ b/backend/src/main/java/org/example/backend/global/entity/BaseEntity.java
@@ -26,12 +26,6 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;    // 엔티티 수정 시 자동 갱신
 
-    @CreatedBy
-    private String createdBy;           // 데이터를 생성한 주체, Spring Security와 연동하여 자동 주입
-
-    @LastModifiedBy
-    private String lastModifiedBy;      // 마지막으로 수정한 주체, 자동 주입
-
     // soft delete 플래그
     private boolean deleted = false;    // 실제 삭제 대신 플래그로 관리한다.
 

--- a/backend/src/main/java/org/example/backend/type/LoginType.java
+++ b/backend/src/main/java/org/example/backend/type/LoginType.java
@@ -1,0 +1,28 @@
+package org.example.backend.type;
+
+import lombok.Getter;
+import java.util.*;
+
+@Getter
+public enum LoginType {
+    LOCAL("local"),
+    KAKAO("kakao"),
+    GOOGLE("google");
+
+    private final String provider;
+
+    LoginType(String provider) {
+        this.provider = provider;
+    }
+
+    public static Optional<LoginType> fromProvider(String provider) {
+        if (provider == null) {
+            return Optional.empty();
+        }
+        String normalized = provider.trim().toLowerCase();
+        return Arrays.stream(LoginType.values())
+                .filter(e -> e.provider.equalsIgnoreCase(normalized))
+                .findFirst();
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/type/LoginType.java
+++ b/backend/src/main/java/org/example/backend/type/LoginType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import java.util.*;
 
 @Getter
-public enum LoginType {
+public enum LoginType {     // 로그인 유형
     LOCAL("local"),
     KAKAO("kakao"),
     GOOGLE("google");

--- a/backend/src/main/java/org/example/backend/type/NotificationType.java
+++ b/backend/src/main/java/org/example/backend/type/NotificationType.java
@@ -1,0 +1,28 @@
+package org.example.backend.type;
+
+import lombok.Getter;
+import java.util.*;
+
+@Getter
+public enum NotificationType {  // 알림 유형
+    PRICE_DROP("급락 알림"),
+    NEWS_EVENT("뉴스 발생 알림"),
+    THRESHOLD("수익률/목표가 임계치 초과 알림");
+
+    private final String description;
+
+    NotificationType(String description) {
+        this.description = description;
+    }
+
+    public static Optional<NotificationType> fromName(String code) {
+        if (code == null) {
+            return Optional.empty();
+        }
+
+        String normalized = code.trim().toUpperCase();
+        return Arrays.stream(NotificationType.values())
+                .filter(e -> e.name().equals(normalized))
+                .findFirst();
+    }
+}

--- a/backend/src/main/java/org/example/backend/type/RoleType.java
+++ b/backend/src/main/java/org/example/backend/type/RoleType.java
@@ -1,0 +1,27 @@
+package org.example.backend.type;
+
+import lombok.Getter;
+import java.util.*;
+
+@Getter
+public enum RoleType {  // 역할 유형
+    ROLE_USER("USER"),
+    ROLE_ADMIN("ADMIN");
+
+    private final String code;
+
+    RoleType(String code) {
+        this.code = code;
+    }
+
+    public static Optional<RoleType> fromCode(String code) {
+        if (code == null) {
+            return Optional.empty();
+        }
+
+        String normalized = code.trim().toUpperCase();
+        return Arrays.stream(RoleType.values())
+                .filter(r -> r.code.equals(normalized))
+                .findFirst();
+    }
+}

--- a/backend/src/main/java/org/example/backend/type/TradeType.java
+++ b/backend/src/main/java/org/example/backend/type/TradeType.java
@@ -1,0 +1,27 @@
+package org.example.backend.type;
+
+import lombok.Getter;
+import java.util.*;
+
+@Getter
+public enum TradeType { // 거래 유형
+    BUY("매수"),
+    SELL("매도");
+
+    private final String description;
+
+    TradeType(String description) {
+        this.description = description;
+    }
+
+    public static Optional<TradeType> fromName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+
+        String normalized = name.trim().toUpperCase();
+        return Arrays.stream(TradeType.values())
+                .filter(t -> t.name().equals(normalized))
+                .findFirst();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
전체적인 Entity 및 연관관계 구현하기

## ✅ To do
- [x] BaseEntity 구현하기
- [x] 사전에 계획 짠 전체적인 Entity 구현하기
- [x] 연관관계 설정하기

## 🧪 테스트 케이스
- [x] DB에 생성되었는지 확인

## ⚠️ 주의 사항
- BaseEntity를 통해 생성일자, 수정일자를 저장하기 위해서는 @EnableJpaAuditing 필요
- 다대다 관계에 대한 연관관계 설정 시 중간 테이블 필요 (User<->WatchList<->Stock)
- 중간 엔티티 구현 시 복합키 사용 (@IdClass(WatchListId.class)) -> 명시적으로 구현
- 필드에 unique 선정 시, 필드마다 선언이 아닌 @UniqueConstraint 사용해서 unique 선정 -> 왜나하면 두 개 이상의 컬럼을 조합해 유니크해야 할 때는 @Column(unique=true)로는 불가능
- List 대신 Set 사용하는 이유는 순서는 상관없고, 중복이 들어가면 안되는 경우 성능적으로 적합하기에 사용한다.